### PR TITLE
Solve the misalignment problem on UNK tokens (MacBERT).

### DIFF
--- a/pycorrector/macbert/infer.py
+++ b/pycorrector/macbert/infer.py
@@ -85,12 +85,13 @@ class Inference:
             sentence_list = [sentence_list]
         corrected_texts = self.model.predict(sentence_list)
 
-        def get_errors(corrected_text, origin_text):
+        def get_errors(corrected_text, origin_text, blank_cleaned=False):
+            # blank_cleaned means if the blanks in texts are cleaned in predict().
             sub_details = []
             for i, ori_char in enumerate(origin_text):
                 if ori_char == " ":
                     # add blank word
-                    _corrected_text = _corrected_text[:i] + ori_char + _corrected_text[i:]
+                    _corrected_text = _corrected_text[:i] + ori_char + _corrected_text[i if blank_cleaned else i + 1:]
                     continue
                 if ori_char in ['“', '”', '‘', '’', '\n', '…', '—']:
                     # add unk word

--- a/pycorrector/macbert/infer.py
+++ b/pycorrector/macbert/infer.py
@@ -85,28 +85,29 @@ class Inference:
             sentence_list = [sentence_list]
         corrected_texts = self.model.predict(sentence_list)
 
-        def get_errors(corrected_text, origin_text, blank_cleaned=False):
-            # blank_cleaned means if the blanks in texts are cleaned in predict().
+        def get_errors(_corrected_text, _origin_text):
             sub_details = []
-            for i, ori_char in enumerate(origin_text):
+            for i, ori_char in enumerate(_origin_text):
                 if ori_char == " ":
                     # add blank word
-                    _corrected_text = _corrected_text[:i] + ori_char + _corrected_text[i if blank_cleaned else i + 1:]
+                    _corrected_text = _corrected_text[:i] + ori_char + _corrected_text[i:]
                     continue
                 if ori_char in ['“', '”', '‘', '’', '\n', '…', '—']:
                     # add unk word
                     _corrected_text = _corrected_text[:i] + ori_char + _corrected_text[i + 1:]
                     continue
-                if i >= len(corrected_text):
+                if i >= len(_corrected_text):
                     continue
-                if ori_char != corrected_text[i]:
-                    if ori_char.lower() == corrected_text[i]:
+                if ori_char != _corrected_text[i]:
+                    # print(ori_char, corrected_text[i])
+                    if (ori_char.lower() == _corrected_text[i]) or _corrected_text[i] == '֍':
                         # pass english upper char
-                        corrected_text = corrected_text[:i] + ori_char + corrected_text[i + 1:]
+                        _corrected_text = _corrected_text[:i] + ori_char + _corrected_text[i + 1:]
                         continue
-                    sub_details.append((ori_char, corrected_text[i], i, i + 1))
+                    sub_details.append((ori_char, _corrected_text[i], i, i + 1))
+                    # print(_corrected_text)
             sub_details = sorted(sub_details, key=operator.itemgetter(2))
-            return corrected_text, sub_details
+            return _corrected_text, sub_details
 
         for corrected_text, text in zip(corrected_texts, sentence_list):
             corrected_text, sub_details = get_errors(corrected_text, text)

--- a/pycorrector/macbert/infer.py
+++ b/pycorrector/macbert/infer.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 """
-@author:XuMing(xuming624@qq.com), Abtion(abtion@outlook.com)
+@author:XuMing(xuming624@qq.com), Abtion(abtion@outlook.com), okcd00(okcd00@qq.com)
 @description: 
 """
 import sys
-import operator
 import torch
+import operator
+from glob import glob
 from transformers import BertTokenizer
 
 sys.path.append('../..')
@@ -25,6 +26,15 @@ class Inference:
         logger.debug("device: {}".format(device))
         self.tokenizer = BertTokenizer.from_pretrained(vocab_path)
         cfg.merge_from_file(cfg_path)
+        
+        if os.path.isdir(ckpt_path):
+            # ckpt_path is allowed to be a path to a directory.
+            # e.g., "output/macbert4csc/epoch=09-val_loss=0.01.ckpt" or 
+            #       "output/macbert4csc/" both are OK.
+            # automatically select the model file with the lowest loss.
+            ckpt_path = sorted(glob(f"{ckpt_path}/*.ckpt"), 
+                               key=lambda x: float(x[:-5].split('=')[-1]))[-1]
+        
         if 'macbert4csc' in cfg_path:
             self.model = MacBert4Csc.load_from_checkpoint(checkpoint_path=ckpt_path,
                                                           cfg=cfg,
@@ -80,7 +90,7 @@ class Inference:
             for i, ori_char in enumerate(origin_text):
                 if ori_char in [' ', '“', '”', '‘', '’', '琊', '\n', '…', '—', '擤']:
                     # add unk word
-                    corrected_text = corrected_text[:i] + ori_char + corrected_text[i:]
+                    corrected_text = corrected_text[:i] + ori_char + corrected_text[i + 1:]
                     continue
                 if i >= len(corrected_text):
                     continue

--- a/pycorrector/macbert/infer.py
+++ b/pycorrector/macbert/infer.py
@@ -76,14 +76,23 @@ class Inference:
             sentence_list = [sentence_list]
         corrected_texts = self.model.predict(sentence_list)
 
-        def get_errors(_corrected_text, _origin_text, blanks_cleaned=False):
+        def get_errors(_corrected_text, _origin_text):
             sub_details = []
+            
+            # Flags, we found that blanks are remained but enters are cleaned.
+            blanks_cleaned = False
+            enter_cleaned = True
+            
             for i, ori_char in enumerate(_origin_text):
                 if ori_char == " ":
                     # add blank word
                     _corrected_text = _corrected_text[:i] + ori_char + _corrected_text[i if blanks_cleaned else i + 1:]
                     continue
-                if ori_char in ['“', '”', '‘', '’', '\n', '…', '—']:
+                if ori_char == "\n":
+                    # add enter word
+                    _corrected_text = _corrected_text[:i] + ori_char + _corrected_text[i if enter_cleaned else i + 1:]
+                    continue
+                if ori_char in ['“', '”', '‘', '’', '琊', '…', '—', '擤']:
                     # add unk word
                     _corrected_text = _corrected_text[:i] + ori_char + _corrected_text[i + 1:]
                     continue

--- a/pycorrector/macbert/infer.py
+++ b/pycorrector/macbert/infer.py
@@ -88,9 +88,13 @@ class Inference:
         def get_errors(corrected_text, origin_text):
             sub_details = []
             for i, ori_char in enumerate(origin_text):
-                if ori_char in [' ', '“', '”', '‘', '’', '琊', '\n', '…', '—', '擤']:
+                if ori_char == " ":
+                    # add blank word
+                    _corrected_text = _corrected_text[:i] + ori_char + _corrected_text[i:]
+                    continue
+                if ori_char in ['“', '”', '‘', '’', '\n', '…', '—']:
                     # add unk word
-                    corrected_text = corrected_text[:i] + ori_char + corrected_text[i + 1:]
+                    _corrected_text = _corrected_text[:i] + ori_char + _corrected_text[i + 1:]
                     continue
                 if i >= len(corrected_text):
                     continue
@@ -121,6 +125,7 @@ if __name__ == "__main__":
     inputs = [
         '它的本领是呼风唤雨，因此能灭火防灾。狎鱼后面是獬豸。獬豸通常头上长着独角，有时又被称为独角羊。它很聪彗，而且明辨是非，象征着大公无私，又能镇压斜恶。',
         '老是较书。',
+        '少先队 员因该 为老人让 坐',
         '感谢等五分以后，碰到一位很棒的奴生跟我可聊。',
         '遇到一位很棒的奴生跟我聊天。',
         '遇到一位很美的女生跟我疗天。',


### PR DESCRIPTION
Fixed an issue which leads to misalignment in correction details. 
It also occurs on `Official Demo: http://42.193.145.218/product/corrector/`   

![image](https://user-images.githubusercontent.com/9395067/156761799-730f4cff-34bd-4eaa-a353-4eb8ab55994a.png)

```python
# run the file pycorrector/macbert/infer.py # `__main__`

inputs = [ '少先队 员因该 为老人让 坐', '你说：“怎么办？”我怎么知道？' ]
outputs, details = m.predict_with_error_detail(inputs)
print(details)
```

**before this PR**
```python
[[('因', '应', 5, 6), ('坐', '座', 13, 14)], [('怎', '「', 4, 5), ('么', '怎', 5, 6), ('办', '么', 6, 7), ('？', '办', 7, 8), ('我', '？', 9, 10), ('怎', '」', 10, 11), ('么', '我', 11, 12), ('知', '怎', 12, 13), ('道', '么', 13, 14), ('？', '知', 14, 15)]]

input  : 少先队 员因该 为老人让 坐
predict: 少先队 员应该 为老人让 座

input  : 你说：“怎么办？”我怎么知道？
corrected_text: 你说：“「怎么办”？」我怎么知道？  # the corrected_text in `get_errors()`
predict: 你说：「怎么办？」我怎么知道？  # 因为 get_errors() 里的修改更新传入 list 所以输出没有改变
```

**after this PR**
```python
[[('因', '应', 5, 6), ('坐', '座', 13, 14)], []]

input  : 少先队 员因该 为老人让 坐
predict: 少先队 员应该 为老人让 座

input  : 你说：“怎么办？”我怎么知道？
corrected_text: 你说：“怎么办？”我怎么知道？  # the corrected_text in `get_errors()` 
predict: 你说：「怎么办？」我怎么知道？  # 这里是否需要让 get_errors() 改变 predict 的输出？
```

```python
# 如果需要让 get_errors() 改变 predict 的输出

# before
for corrected_text, text in zip(corrected_texts, sentence_list):
    corrected_text, sub_details = get_errors(corrected_text, text)
    details.append(sub_details)
if is_str:
    return corrected_texts[0], details[0]
return corrected_texts, details  # `corrrected_texts` remains unchanged

# after
modified_texts = []
for corrected_text, text in zip(corrected_texts, sentence_list):
    corrected_text, sub_details = get_errors(corrected_text, text)
    modified_texts.append(corrected_text)
    details.append(sub_details)

if is_str:
    return modified_texts[0], details[0]
return modified_texts, details
```