### PR TITLE
库依赖跟新和最低版本要求更新

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,8 +7,10 @@ scikit-learn>=0.19.1
 torch>=1.3.1
 pytorch-lightning>=1.1.2
 pandas
-transformers>=4.4.2
+transformers>=4.28.1
+accelerate
 datasets
 tensorboardX
 paddlenlp
 paddlepaddle
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ six
 loguru
 kenlm
 pandas
-transformers >= 4.28.1
+transformers>=4.28.1
+accelerate
 datasets

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ six
 loguru
 kenlm
 pandas
-transformers
+transformers >= 4.28.1
 datasets


### PR DESCRIPTION
加入了GPTcorrector之后, 无法使用没有llamaTokenizer的Transformers版本